### PR TITLE
Added one-event processing option to CompiledLogicNet

### DIFF
--- a/src/torchlogix/compiled_model.py
+++ b/src/torchlogix/compiled_model.py
@@ -969,7 +969,7 @@ void apply_logic_net(bool const *inp, {BITS_TO_DTYPE[32]} *out, size_t len) {{
         ]
 
         if self.num_classes:
-            code.append(f"bool out_temp[{num_neurons_ll}];")
+            code.append(f"  bool out_temp[{num_neurons_ll}];")
 
         if self.apply_thresholding:
             code.append(f"""


### PR DESCRIPTION
DRAFT
- enables one-event processing by setting `use_bitpacking=False`
- implements thresholding layer for models where present 
- implements num_bits=1 option as alternative to `use_bitpacking=False`
- implements tau and beta for GroupSum layer