### PR TITLE
Fix random index conv

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,10 @@ name: Documentation
 on:
   push:
     branches: [ main, master ]
-  workflow_dispatch:  # Allows manual triggering
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   docs:

--- a/tests/test_clgn.py
+++ b/tests/test_clgn.py
@@ -190,8 +190,8 @@ def test_and_model():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0], [1, 0, 0]]),
-        torch.tensor([[0, 1, 0], [1, 1, 0]]),
+        torch.tensor([[[0, 0, 0], [1, 0, 0]]]),
+        torch.tensor([[[0, 1, 0], [1, 1, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 
@@ -255,8 +255,8 @@ def test_and_model_walsh():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0], [1, 0, 0]]),
-        torch.tensor([[0, 1, 0], [1, 1, 0]]),
+        torch.tensor([[[0, 0, 0], [1, 0, 0]]]),
+        torch.tensor([[[0, 1, 0], [1, 1, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 
@@ -314,8 +314,8 @@ def test_binary_model():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0], [1, 0, 0]]),
-        torch.tensor([[0, 1, 0], [1, 1, 0]]),
+        torch.tensor([[[0, 0, 0], [1, 0, 0]]]),
+        torch.tensor([[[0, 1, 0], [1, 1, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 
@@ -365,8 +365,8 @@ def test_conv_model():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0], [1, 0, 0]]),
-        torch.tensor([[0, 1, 0], [1, 1, 0]]),
+        torch.tensor([[[0, 0, 0], [1, 0, 0]]]),
+        torch.tensor([[[0, 1, 0], [1, 1, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 
@@ -417,16 +417,16 @@ def test_conv_model_rect():
         channels=1,
         num_kernels=1,
         tree_depth=1,
-            receptive_field_size=2,
-            implementation="python",
-            connections="random-unique",
-            stride=1,
-            padding=0,
+        receptive_field_size=2,
+        implementation="python",
+        connections="random-unique",
+        stride=1,
+        padding=0,
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0, 0], [1, 0, 0, 0]]),
-        torch.tensor([[0, 1, 0, 0], [1, 1, 0, 0]]),
+        torch.tensor([[[0, 0, 0, 0], [1, 0, 0, 0]]]),
+        torch.tensor([[[0, 1, 0, 0], [1, 1, 0, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 

--- a/tests/test_clgn_3d.py
+++ b/tests/test_clgn_3d.py
@@ -194,8 +194,8 @@ def test_and_model():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0, 0], [0, 1, 0, 0]]),
-        torch.tensor([[0, 0, 1, 0], [0, 1, 1, 0]]),
+        torch.tensor([[[0, 0, 0, 0], [0, 1, 0, 0]]]),
+        torch.tensor([[[0, 0, 1, 0], [0, 1, 1, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 
@@ -257,8 +257,8 @@ def test_binary_model():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0, 0], [1, 0, 0, 0]]),
-        torch.tensor([[0, 1, 0, 0], [1, 1, 0, 0]]),
+        torch.tensor([[[0, 0, 0, 0], [1, 0, 0, 0]]]),
+        torch.tensor([[[0, 1, 0, 0], [1, 1, 0, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 
@@ -307,8 +307,8 @@ def test_conv_model():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0, 0], [1, 0, 0, 0]]),
-        torch.tensor([[0, 1, 0, 0], [1, 1, 0, 0]]),
+        torch.tensor([[[0, 0, 0, 0], [1, 0, 0, 0]]]),
+        torch.tensor([[[0, 1, 0, 0], [1, 1, 0, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 
@@ -380,8 +380,8 @@ def test_conv_model_rect():
     )
 
     kernel_pairs = (
-        torch.tensor([[0, 0, 0, 0], [1, 0, 0, 0]]),
-        torch.tensor([[0, 1, 0, 0], [1, 1, 0, 0]]),
+        torch.tensor([[[0, 0, 0, 0], [1, 0, 0, 0]]]),
+        torch.tensor([[[0, 1, 0, 0], [1, 1, 0, 0]]]),
     )
     layer.indices = layer.get_indices_from_kernel_pairs(kernel_pairs)
 


### PR DESCRIPTION
This fixes a bug in the convolutional layer where all kernels used the same inputs from receptive field. Each kernel now uses a different set of inputs (drawn at random).