### PR TITLE
fix: register indices as buffer in dense

### DIFF
--- a/src/torchlogix/connections.py
+++ b/src/torchlogix/connections.py
@@ -349,9 +349,13 @@ class FixedConvConnections(Connections):
             assert channels > channel_group_size, (
                 "channel_group_size must be smaller than the number of channels"
             )
-        self.indices = self._init_connections()
-        
-        
+        for i, tensor in enumerate(self._init_connections()):
+            self.register_buffer(f'_indices_L{i}', tensor)
+
+    @property
+    def indices(self):
+        return [getattr(self, f'_indices_L{i}') for i in range(self.tree_depth)]
+
     def _init_connections(self):
         # Setup connections
         if self.init_method == "random":

--- a/src/torchlogix/connections.py
+++ b/src/torchlogix/connections.py
@@ -356,6 +356,11 @@ class FixedConvConnections(Connections):
     def indices(self):
         return [getattr(self, f'_indices_L{i}') for i in range(self.tree_depth)]
 
+    @indices.setter
+    def indices(self, value):
+        for i, tensor in enumerate(value):
+            self.register_buffer(f'_indices_L{i}', tensor)
+
     def _init_connections(self):
         # Setup connections
         if self.init_method == "random":

--- a/src/torchlogix/connections.py
+++ b/src/torchlogix/connections.py
@@ -102,7 +102,7 @@ class FixedDenseConnections(Connections):
         )
         self.in_dim = in_dim
         self.out_dim = out_dim
-        self.indices = self._init_connections()
+        self.register_buffer('indices', self._init_connections())
 
     def _init_connections(self):
         """Constructs possible input–neuron connection indices.
@@ -223,12 +223,12 @@ class LearnableDenseConnections(Connections):
         if num_candidates == -1:
             num_candidates = in_dim
             self.num_candidates = num_candidates
-            self.indices = torch.arange(in_dim, device=self.device).view(
-                in_dim, 1, 1).expand(in_dim, lut_rank, out_dim)
+            self.register_buffer('indices', torch.arange(in_dim, device=self.device).view(
+                in_dim, 1, 1).expand(in_dim, lut_rank, out_dim).contiguous())
         else:
             assert num_candidates > 0, "num_candidates must be bigger than 0"
             self.num_candidates = num_candidates
-            self.indices = self._init_connections()
+            self.register_buffer('indices', self._init_connections())
         self.weights = torch.nn.Parameter(torch.rand(
             num_candidates, lut_rank, out_dim, dtype=torch.float32), requires_grad=True)
         

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,81 @@
+import pytest
+import subprocess
+import ctypes
+import sys
+import tempfile
+import torch
+import torch.nn as nn
+from torchlogix.layers import (
+    GroupSum,
+    LogicConv2d,
+    LogicConv3d,
+    LogicDense,
+    OrPooling2d,
+    OrPooling3d,
+)
+
+
+class DenseModel(nn.Sequential):
+    def __init__(self):
+        super().__init__(
+            LogicDense(1000, 1000, parametrization="raw", parametrization_kwargs={"weight_init": "random"}),
+            LogicDense(1000, 1000, parametrization="raw", parametrization_kwargs={"weight_init": "random"}),
+        )
+        self.input_shape = (1000,)
+
+
+# inherit from sequential
+class ConvModel(nn.Sequential):
+    def __init__(self):
+        super().__init__(
+            LogicConv2d(in_dim=32, channels=3, num_kernels=8, receptive_field_size=3, tree_depth=2, parametrization_kwargs={"weight_init": "random"}),
+            OrPooling2d(kernel_size=2, stride=2),
+            nn.Flatten(),  # 8 × 15 x 15 = 1800
+            LogicDense(1800, 1000, parametrization="raw", parametrization_kwargs={"weight_init": "random"}),
+            LogicDense(1000, 1000, parametrization="raw", parametrization_kwargs={"weight_init": "random"}),
+            GroupSum(10)# , tau=2.0),
+        )
+        self.input_shape = (3, 32, 32)
+
+
+# w/ custom forward pass
+class BranchModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = LogicConv2d(in_dim=32, channels=3, num_kernels=8,
+                    receptive_field_size=3, tree_depth=2,
+                    parametrization_kwargs={"weight_init": "random"}) # 8 x 30 x 30 = 7200
+        self.pool = OrPooling2d(kernel_size=2, stride=2) # 8 x 15 x 15 = 1800
+        self.dense = LogicDense(1801, 1000, parametrization="raw", parametrization_kwargs={"weight_init": "random"})
+        self.group_sum = GroupSum(10)
+        self.input_shape = (32*32*3 + 1,)
+
+    def forward(self, x):
+        assert x.shape[1:] == (32*32*3 + 1,)
+        img, feat = x[:, :-1].reshape(-1, 3, 32, 32), x[:, -1:]
+        x = self.conv(img)
+        x = self.pool(x)
+        x = x.flatten(1)
+        x = torch.cat([x, feat], dim=1)
+        x = self.dense(x)
+        x = self.group_sum(x)
+        return x
+    
+
+# @pytest.mark.parametrize("model_class", [DenseModel, ConvModel, BranchModel])
+@pytest.mark.parametrize("model_class", [DenseModel])
+def test_round_trip(model_class):
+    # write model to disk, reaload it and assert that the outputs are the same
+    x = torch.randn(1, *model_class().input_shape)
+
+    model = model_class()
+    out_original = model(x)
+
+    # safe to file
+    model_loaded = model_class()
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        torch.save(model.state_dict(), tmp.name)
+        model_loaded.load_state_dict(torch.load(tmp.name))
+
+    out_loaded = model_loaded(x)
+    assert torch.allclose(out_original, out_loaded, atol=1e-5), "Original and loaded outputs do not match"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,8 +62,7 @@ class BranchModel(nn.Module):
         return x
     
 
-# @pytest.mark.parametrize("model_class", [DenseModel, ConvModel, BranchModel])
-@pytest.mark.parametrize("model_class", [DenseModel])
+@pytest.mark.parametrize("model_class", [DenseModel, ConvModel, BranchModel])
 def test_round_trip(model_class):
     # write model to disk, reaload it and assert that the outputs are the same
     x = torch.randn(1, *model_class().input_shape)


### PR DESCRIPTION
## Problem
`FixedDenseConnections` and `LearnableDenseConnections` store their wiring tensor as a plain Python attribute (`self.indices = ...`). Plain attributes are silently ignored by `state_dict()`, so connections are never saved. On reload, fresh random connections are generated and the loaded weights are applied to the wrong wiring, producing garbage outputs.

## Fix
Changed both assignments to `self.register_buffer('indices', ...)`. In the `LearnableDenseConnections` `num_candidates=-1` branch, `.contiguous()` is added because `.expand()` returns a non-contiguous view.

## Not fixed
`FixedConvConnections` has the same bug but was not touched here, its `_init_connections` returns a list of tensors with different shapes, which cannot be registered as a single buffer. Requires a separate refactor.

Closes #22