### PR TITLE
bugfix: conv connections reshaping now works w/ torch.compile

### DIFF
--- a/src/torchlogix/connections.py
+++ b/src/torchlogix/connections.py
@@ -675,7 +675,10 @@ class FixedConvConnections(Connections):
     
     def forward(self, x, tree_level):
         if tree_level == 0:
-            return x[(slice(None), self.indices[0][..., -1], 
-              *self.indices[0][..., :-1].moveaxis(-1, 0))]
+            # unbind is used instead of * unpacking, which torch.compile cannot trace correctly
+            index_tensors = self.indices[0].unbind(-1)  # (h, w[, d], c) — each (L, K, P, S)
+            c_idx = index_tensors[-1]
+            spatial_idx = index_tensors[:-1]
+            return x[(slice(None), c_idx) + spatial_idx]
         else:
             return x[..., self.indices[tree_level]]

--- a/tests/test_export_mode.py
+++ b/tests/test_export_mode.py
@@ -189,6 +189,7 @@ ALLOWED_FX_TARGETS = {
     torch.ops.aten.transpose.int,
     torch.ops.aten.pad.default,
     torch.ops.aten.unfold.default,
+    torch.ops.aten._unsafe_view.default,
 
     # Advanced view variants
     torch.ops.aten.view.default,
@@ -200,12 +201,14 @@ ALLOWED_FX_TARGETS = {
 
     # Index writes
     torch.ops.aten.index_put_.default,
+    torch.ops.aten.index_put.default,
 
     # Constants and copies
     torch.ops.aten.zeros_like.default,
     torch.ops.aten.ones_like.default,
     torch.ops.aten.empty_like.default,
     torch.ops.aten.lift_fresh_copy.default,
+    torch.ops.aten.clone.default,
 
     # Symbolic shape system (export internals)
     torch.ops.aten.sym_size.int,


### PR DESCRIPTION
The final reshaping in convolutional connections did not throw and error, but produced a different result when compiled with torch.compile. a nasty bug that lead to compiled conv models training much worse than in eager mode